### PR TITLE
Changed component type and added tags. Fixes #32.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,11 @@
                     <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
                     <documentationUrl>https://jcustenborder.github.io/kafka-connect-documentation/</documentationUrl>
                     <componentTypes>
-                        <componentType>source</componentType>
+                        <componentType>transform</componentType>
                     </componentTypes>
                     <tags>
-                        <tag>Twitter</tag>
-                        <tag>Social</tag>
+                        <tag>Common</tag>
+                        <tag>Transformation</tag>
                     </tags>
                     <title>Kafka Connect Common Transformations</title>
                     <supportUrl>${pom.issueManagement.url}</supportUrl>


### PR DESCRIPTION
The plugin type is still `Source` on Hub (https://www.confluent.io/hub/jcustenborder/kafka-connect-transform-common) making it harder to find these SMTs