### PR TITLE
Extract XPath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,16 @@
             <version>[0.3.33,0.3.1000)</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.ws.commons</groupId>
+            <artifactId>ws-commons-util</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.12.1</version>
+        </dependency>        
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import com.github.jcustenborder.kafka.connect.utils.config.Description;
+import com.github.jcustenborder.kafka.connect.utils.config.DocumentationTip;
+import com.github.jcustenborder.kafka.connect.utils.config.Title;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
+
+import org.apache.ws.commons.util.NamespaceContextImpl;
+
+public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTransformation<R> {
+  private static final Logger log = LoggerFactory.getLogger(ExtractXPath.class);
+
+
+  ExtractXPathConfig config;
+  public ExtractXPathConfig theConfig() {
+    return this.config;
+  }
+
+  DocumentBuilder builder;
+  XPath xpath;
+  XPathExpression xpathE;
+  LSSerializer writer;
+
+  @Override
+  public ConfigDef config() {
+    return ExtractXPathConfig.config();
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> settings) {
+    this.config = new ExtractXPathConfig(settings);
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(config.namespaceAware);
+      builder = factory.newDocumentBuilder();
+      xpath = XPathFactory.newInstance().newXPath();
+      if (config.namespaceAware) {
+        NamespaceContextImpl nsContext = new NamespaceContextImpl();
+        for (int i = 0; i < config.prefixes.size(); i++) {
+          String prefix = config.prefixes.get(i);
+          String ns = config.namespaces.get(i);
+          log.debug("Adding prefix {} for namespace {}", prefix, ns);
+          nsContext.startPrefixMapping(prefix, ns);
+        }
+        xpath.setNamespaceContext(nsContext);
+      }
+      xpathE = xpath.compile(config.xpath);
+
+      DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
+      DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
+      writer = impl.createLSSerializer();
+    } catch (Exception e) {
+      log.error("Unable to create transformer {} {}", e.getMessage(), e.toString());
+    }
+  }
+
+  /**
+   * 
+   */
+  private String extractXPathString(Object inData) {
+    if (inData instanceof String) {
+      try {
+        String inFieldData = (String) inData;
+        InputStream in = new ByteArrayInputStream(inFieldData.getBytes());
+        Document doc = builder.parse(in);
+        Node node = (Node) xpathE.evaluate(doc, XPathConstants.NODE);
+        return writer.writeToString(node);  
+      } catch (Exception e) {
+        log.error("Unable to evaluate XPath {} {}", e.getMessage(), e.toString());
+      }
+    } else {
+      log.error("Expected a String, got a {}", inData.getClass().getName());
+    }
+    return null;
+  }
+  @Override
+  protected SchemaAndValue processStruct(R record, Schema inputSchema, Struct inputStruct) {
+    Schema outPutSchema = inputSchema;
+    SchemaAndValue retVal = null;
+    if (!config.outputField.equals(config.inputField)) {
+      // Adding a new field, need to build a new schema
+      final SchemaBuilder outputSchemaBuilder = SchemaBuilder.struct();
+      outputSchemaBuilder.name(inputSchema.name());
+      outputSchemaBuilder.doc(inputSchema.doc());
+      if (null != inputSchema.defaultValue()) {
+        outputSchemaBuilder.defaultValue(inputSchema.defaultValue());
+      }
+      if (null != inputSchema.parameters() && !inputSchema.parameters().isEmpty()) {
+        outputSchemaBuilder.parameters(inputSchema.parameters());
+      }
+      if (inputSchema.isOptional()) {
+        outputSchemaBuilder.optional();
+      }
+      for (final Field inputField : inputSchema.fields()) {
+        final String inputFieldName = inputField.name();
+        log.trace("process() - Schema has field '{}'", inputFieldName);
+        outputSchemaBuilder.field(inputFieldName, inputField.schema());
+        if (inputFieldName.equals(config.inputField)) {
+          log.trace("process() - Adding field '{}'", config.outputField);
+          outputSchemaBuilder.field(config.outputField, inputField.schema());
+        }
+      }
+      final Schema newSchema = outputSchemaBuilder.build();
+      final Struct outputStruct = new Struct(newSchema);
+      for (final Field inputField : inputSchema.fields()) {
+        final String inputFieldName = inputField.name();
+        final Object value = inputStruct.get(inputFieldName);
+        outputStruct.put(inputFieldName, value);
+        if (inputFieldName.equals(config.inputField)) {
+          String extractedValue = extractXPathString(value);
+          outputStruct.put(config.outputField, extractedValue);
+        }
+      }
+      retVal = new SchemaAndValue(newSchema, outputStruct);
+    } else {
+      Struct outputStruct = inputStruct;
+      Object toReplace = inputStruct.get(config.inputField);
+      if (toReplace != null && toReplace instanceof String) {
+        String inputFieldName = config.inputField;
+        String replacedField = (String) toReplace;
+        log.trace("process() - Processing struct field '{}' value '{}'", inputFieldName, toReplace);
+        String extractedValue = extractXPathString(replacedField);
+        if (config.outputField.equals(config.inputField)) {
+          log.debug("process() - Replaced struct field '{}' with '{}'", inputFieldName, extractedValue);
+        } else {
+          log.debug("process() - Added struct field '{}' with '{}'", config.outputField, extractedValue);
+        }
+        outputStruct.put(config.outputField, extractedValue);
+        retVal = new SchemaAndValue(outPutSchema, outputStruct);
+      }
+    }
+    return retVal;
+  }
+
+  @Override
+  protected SchemaAndValue processMap(R record, Map<String, Object> input) {
+    Map<String, Object> outputMap = new LinkedHashMap<>(input.size());
+    for (final String inputFieldName : input.keySet()) {
+      outputMap.put(inputFieldName, input.get(inputFieldName));
+      log.trace("process() - Processing map field '{}' value '{}'", inputFieldName, input.get(inputFieldName));
+      if (inputFieldName.equals(config.inputField)) {
+        String fieldToMatch = (String) input.get(inputFieldName);
+        String replacedValue = extractXPathString(fieldToMatch);
+        outputMap.put(config.outputField, replacedValue);
+        if (config.outputField.equals(config.inputField)) {
+          log.debug("process() - Replaced map field '{}' with '{}'", inputFieldName, replacedValue);
+        } else {
+          log.debug("process() - Added map field '{}' with '{}'", config.outputField, replacedValue);
+        }
+      }
+    }
+    return new SchemaAndValue(null, outputMap);
+  }
+
+  @Title("ExtractXPathConfig(Key)")
+  @Description("This transformation is used to take structured data such as AVRO and output it as " +
+      "JSON by way of the JsonConverter built into Kafka Connect.")
+  @DocumentationTip("This transformation is used to manipulate fields in the Key of the record.")
+  public static class Key<R extends ConnectRecord<R>> extends ExtractXPath<R> {
+
+    @Override
+    public R apply(R r) {
+      final SchemaAndValue transformed = process(r, r.keySchema(), r.key());
+
+      return r.newRecord(
+          r.topic(),
+          r.kafkaPartition(),
+          transformed.schema(),
+          transformed.value(),
+          r.valueSchema(),
+          r.value(),
+          r.timestamp()
+      );
+    }
+  }
+
+  @Title("ExtractXPathConfig(Value)")
+  @Description("This transformation is used to take structured data such as AVRO and output it as " +
+      "JSON by way of the JsonConverter built into Kafka Connect.")
+  public static class Value<R extends ConnectRecord<R>> extends ExtractXPath<R> {
+
+    @Override
+    public R apply(R r) {
+      final SchemaAndValue transformed = process(r, r.valueSchema(), r.value());
+
+      return r.newRecord(
+          r.topic(),
+          r.kafkaPartition(),
+          r.keySchema(),
+          r.key(),
+          transformed.schema(),
+          transformed.value(),
+          r.timestamp()
+      );
+    }
+  }
+
+}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
@@ -106,10 +106,13 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
     if (inData instanceof String) {
       try {
         String inFieldData = (String) inData;
+        log.trace("Input data\n{}", inFieldData);
         InputStream in = new ByteArrayInputStream(inFieldData.getBytes());
         Document doc = builder.parse(in);
         Node node = (Node) xpathE.evaluate(doc, XPathConstants.NODE);
-        return writer.writeToString(node);  
+        String output = writer.writeToString(node);
+        log.trace("Transformed data\n{}", output);
+        return output;  
       } catch (Exception e) {
         log.error("Unable to evaluate XPath {} {}", e.getMessage(), e.toString());
       }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
@@ -141,12 +141,13 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
   protected SchemaAndValue processBytes(R record, Schema inputSchema, byte[] input) {
     Schema outPutSchema = inputSchema;
     SchemaAndValue retVal = null;
-    log.trace("process() - Processing bytes");
-    Object extractedValue = extractXPathString(input);
-    retVal = new SchemaAndValue(outPutSchema, extractedValue);
+    log.trace("process() - Processing bytes Input: {}", new String(input));
+    Object outputValue = extractXPathString(input);
+    log.trace("process() - Output: {}", new String((byte[]) outputValue));
+    retVal = new SchemaAndValue(outPutSchema, outputValue);
     return retVal;
   }
-  
+
   @Override
   protected SchemaAndValue processStruct(R record, Schema inputSchema, Struct inputStruct) {
     Schema outPutSchema = inputSchema;
@@ -227,8 +228,8 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
   }
   
   @Title("ExtractXPathConfig(Key)")
-  @Description("This transformation is used to take structured data such as AVRO and output it as " +
-      "JSON by way of the JsonConverter built into Kafka Connect.")
+  @Description("This transformation is used to take XML data and apply an XPath to  " +
+      "it, returning a new XML document.")
   @DocumentationTip("This transformation is used to manipulate fields in the Key of the record.")
   public static class Key<R extends ConnectRecord<R>> extends ExtractXPath<R> {
     
@@ -249,8 +250,8 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
   }
   
   @Title("ExtractXPathConfig(Value)")
-  @Description("This transformation is used to take structured data such as AVRO and output it as " +
-      "JSON by way of the JsonConverter built into Kafka Connect.")
+  @Description("This transformation is used to take XML data and apply an XPath to  " +
+      "it, returning a new XML document.")
   public static class Value<R extends ConnectRecord<R>> extends ExtractXPath<R> {
     
     @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
@@ -72,8 +72,8 @@ public class ExtractXPathConfig extends AbstractConfig {
 
   public static ConfigDef config() {
     return new ConfigDef()
-    .define(IN_FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, IN_FIELD_DOC)
-    .define(OUT_FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, OUT_FIELD_DOC)
+    .define(IN_FIELD_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, IN_FIELD_DOC)
+    .define(OUT_FIELD_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, OUT_FIELD_DOC)
     .define(XPATH_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, XPATH_DOC)
     .define(NS_LIST_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_LIST_DOC)
     .define(NS_PREFIX_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_PREFIX_DOC);

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExtractXPathConfig extends AbstractConfig {
+  private static final Logger log = LoggerFactory.getLogger(ExtractXPathConfig.class);
+
+  public final String inputField;
+  public final String outputField;
+  public final String xpath;
+  public final boolean namespaceAware;
+  public final List<String> prefixes;
+  public final List<String> namespaces;
+
+  public static final String IN_FIELD_CONFIG = "input.field";
+  public static final String IN_FIELD_DOC = "The input field containing the XML Document.";
+  public static final String OUT_FIELD_CONFIG = "output.field";
+  public static final String OUT_FIELD_DOC = "The output field where the XML element matching the XPath will be placed.";
+  public static final String NS_PREFIX_CONFIG = "ns.prefix";
+  public static final String NS_PREFIX_DOC = "A comma separated list of Namespace prefixes";
+  public static final String NS_LIST_CONFIG = "ns.namespace";
+  public static final String NS_LIST_DOC = "A comma separated list of Namespaces corresponding to the prefixes";
+  public static final String XPATH_CONFIG = "xpath";
+  public static final String XPATH_DOC = "The XPath to apply to extract an element from the Document";
+
+
+
+  public ExtractXPathConfig(Map<String, ?> settings) {
+    super(config(), settings);
+    this.inputField = getString(IN_FIELD_CONFIG);    
+    this.outputField = getString(OUT_FIELD_CONFIG);
+    this.xpath = getString(XPATH_CONFIG);
+    String prefixString = getString(NS_PREFIX_CONFIG);
+    String namespaceString = getString(NS_LIST_CONFIG);
+    if (prefixString == null || prefixString.trim().length() == 0) {
+      this.namespaceAware = false;
+      prefixes = new ArrayList<String>();
+      namespaces = new ArrayList<String>();
+    } else {
+      this.namespaceAware = true;
+      prefixes = Arrays.asList(prefixString.split(","));
+      namespaces = Arrays.asList(namespaceString.split(","));
+      if (namespaces.size() != prefixes.size()) {
+        log.warn("The list of namespaces and corresponding prefixes are not the same length.");
+      }
+    }
+  }
+
+  public static ConfigDef config() {
+    return new ConfigDef()
+    .define(IN_FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, IN_FIELD_DOC)
+    .define(OUT_FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, OUT_FIELD_DOC)
+    .define(XPATH_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, XPATH_DOC)
+    .define(NS_LIST_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_LIST_DOC)
+    .define(NS_PREFIX_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_PREFIX_DOC);
+  }
+
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -13,6 +13,8 @@ import java.io.UnsupportedEncodingException;
 import java.io.File;
 import com.google.common.io.Files;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,6 +26,7 @@ public abstract class ExtractXPathTest extends TransformationTest {
   protected ExtractXPathTest(boolean isKey) {
     super(isKey);
   }
+  private static final Logger log = LoggerFactory.getLogger(ExtractXPathTest.class);
 
   
   @Test
@@ -101,10 +104,12 @@ public abstract class ExtractXPathTest extends TransformationTest {
         1L
     );
 
+    log.trace("Input: {}", new String(input));
     SinkRecord outputRecord = this.transformation.apply(inputRecord);
     assertNotNull(outputRecord);
     final Schema actualSchema = isKey ? outputRecord.keySchema() : outputRecord.valueSchema();
     final byte[] actualStruct = (byte[]) (isKey ? outputRecord.key() : outputRecord.value());
+    log.trace("Output: {}", new String(actualStruct));
 
     assertSchema(Schema.BYTES_SCHEMA, actualSchema);
     assertEquals(actualStruct.length, expected.length);

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -1,0 +1,84 @@
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class ExtractXPathTest extends TransformationTest {
+  protected ExtractXPathTest(boolean isKey) {
+    super(isKey);
+  }
+
+  /**
+  @Test
+  public void struct() throws UnsupportedEncodingException {
+    this.transformation.configure(
+        ImmutableMap.of(BytesToStringConfig.FIELD_CONFIG, "bytes")
+    );
+    final String expected =  "this is a test";
+    Schema schema = SchemaBuilder.struct()
+        .field("bytes", Schema.BYTES_SCHEMA)
+        .build();
+    Struct struct = new Struct(schema)
+        .put("bytes", expected.getBytes("UTF-8"));
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        schema,
+        struct,
+        1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+  }
+  */
+
+  @Test
+  public void checkConfig1() {
+    this.transformation.configure(
+      ImmutableMap.of(
+        ExtractXPathConfig.IN_FIELD_CONFIG, "in",
+        ExtractXPathConfig.OUT_FIELD_CONFIG, "out",
+        ExtractXPathConfig.XPATH_CONFIG, "//root")
+    );
+    ExtractXPathConfig xpc = ((ExtractXPath) this.transformation).theConfig();
+    assertEquals(xpc.namespaceAware, false);
+  }
+  @Test
+  public void checkConfig2() {
+    this.transformation.configure(
+      ImmutableMap.of(
+        ExtractXPathConfig.IN_FIELD_CONFIG, "in",
+        ExtractXPathConfig.OUT_FIELD_CONFIG, "out",
+        ExtractXPathConfig.XPATH_CONFIG, "//ns1:root",
+        ExtractXPathConfig.NS_PREFIX_CONFIG, "ns1,ns2,ns3",
+        ExtractXPathConfig.NS_LIST_CONFIG, "http://ns1.io/one,http://ns2.io/two,http://ns3.io/three")
+    );
+    ExtractXPathConfig xpc = ((ExtractXPath) this.transformation).theConfig();
+    assertEquals(xpc.namespaceAware, true);
+  }
+
+  public static class ValueTest<R extends ConnectRecord<R>> extends ExtractXPathTest {
+    protected ValueTest() {
+      super(false);
+    }
+
+    @Override
+    protected Transformation<SinkRecord> create() {
+      return new ExtractXPath.Value<>();
+    }
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -81,6 +81,39 @@ public abstract class ExtractXPathTest extends TransformationTest {
   public void SOAPEnvelopeByte() throws UnsupportedEncodingException, IOException {
     this.transformation.configure(
       ImmutableMap.of(
+        ExtractXPathConfig.XPATH_CONFIG, "//ns1:Transaction/ns1:Transaction",
+        ExtractXPathConfig.NS_PREFIX_CONFIG, "soap,ns1",
+        ExtractXPathConfig.NS_LIST_CONFIG, "http://www.w3.org/2003/05/soap-envelope/,http://test.confluent.io/test/abc.xsd"
+      )
+    );
+
+    final byte[] expected = Files.toByteArray(new File("src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/Transaction.xml"));
+    
+    final byte[] input = Files.toByteArray(new File("src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/SOAPEnvelope1.xml"));
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        Schema.BYTES_SCHEMA,
+        input,
+        1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+    assertNotNull(outputRecord);
+    final Schema actualSchema = isKey ? outputRecord.keySchema() : outputRecord.valueSchema();
+    final byte[] actualStruct = (byte[]) (isKey ? outputRecord.key() : outputRecord.value());
+
+    assertSchema(Schema.BYTES_SCHEMA, actualSchema);
+    assertEquals(actualStruct.length, expected.length);
+  
+  }
+  @Test
+  public void SOAPEnvelopeStructByte() throws UnsupportedEncodingException, IOException {
+    this.transformation.configure(
+      ImmutableMap.of(
         ExtractXPathConfig.IN_FIELD_CONFIG, "in",
         ExtractXPathConfig.OUT_FIELD_CONFIG, "out",
         ExtractXPathConfig.XPATH_CONFIG, "//ns1:Transaction/ns1:Transaction",

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/SOAPEnvelope1.xml
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/SOAPEnvelope1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<soap:Envelope
+xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+
+<soap:Header>
+</soap:Header>
+
+<soap:Body>
+    <abc:Transaction xmlns:abc="http://test.confluent.io/test/abc.xsd">
+        <Transaction xmlns="http://test.confluent.io/test/abc.xsd">
+            <SomeID>12345</SomeID>
+        </Transaction>
+    </abc:Transaction>
+  </soap:Body>
+
+</soap:Envelope>

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/Transaction.xml
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath/Transaction.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Transaction xmlns="http://test.confluent.io/test/abc.xsd">
+            <SomeID>12345</SomeID>
+        </Transaction>


### PR DESCRIPTION
Pulls out a string from an XML document by using XSLT.
This was necessary in order to use the XML2JSON SMT for SOAP requests, as the "any" type in the payload breaks the parsing. Using this SMT first you can pull out the contents of the SOAP:Body element and just parse that.