### PR TITLE
Allow TimestampNowField to output TTL for DynamoDB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+[*.java]
+indent_style = space
+indent_size = 2

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowField.java
@@ -22,13 +22,18 @@ import com.github.jcustenborder.kafka.connect.utils.transformation.BaseKeyValueT
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 
 @Title("TimestampNowField")
 @Description("This transformation is used to set a field with the current timestamp of the system running the " +

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowField.java
@@ -22,20 +22,11 @@ import com.github.jcustenborder.kafka.connect.utils.transformation.BaseKeyValueT
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.*;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Title("TimestampNowField")
@@ -84,7 +75,7 @@ public abstract class TimestampNowField<R extends ConnectRecord<R>> extends Base
               case Date:
                 return !isTimestampSchema(f.schema());
               case Unix:
-                return f.schema().type() != Schema.Type.INT64;
+                return f.schema().type() != Schema.Type.INT64 || f.schema().name() != null;
             }
           })
           .map(Field::name)

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
@@ -79,7 +79,7 @@ class TimestampNowFieldConfig extends AbstractConfig {
             ConfigKeyBuilder.of(TARGET_TYPE_CONF, ConfigDef.Type.STRING)
                 .documentation(TARGET_TYPE_DOC)
                 .importance(ConfigDef.Importance.LOW)
-                .defaultValue("Date")
+                .defaultValue("DATE")
                 .validator(Validators.validEnum(TimestampNowFieldTargetType.class))
                 .build()
         );

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
@@ -45,14 +45,14 @@ class TimestampNowFieldConfig extends AbstractConfig {
   public final Long addAmount;
   public final ChronoUnit addChronoUnit;
 
-  public final TargetType targetType;
+  public final TimestampNowFieldTargetType targetType;
 
   public TimestampNowFieldConfig(Map<?, ?> originals) {
     super(config(), originals);
     this.fields = ConfigUtils.getSet(this, FIELDS_CONF);
     this.addAmount = getLong(ADD_AMOUNT_CONF);
     this.addChronoUnit = ChronoUnit.valueOf(getString(ADD_CHRONO_UNIT_CONF));
-    this.targetType = ConfigUtils.getEnum(TargetType.class, this, TARGET_TYPE_CONF);
+    this.targetType = ConfigUtils.getEnum(TimestampNowFieldTargetType.class, this, TARGET_TYPE_CONF);
   }
 
   public static ConfigDef config() {
@@ -80,13 +80,8 @@ class TimestampNowFieldConfig extends AbstractConfig {
                 .documentation(TARGET_TYPE_DOC)
                 .importance(ConfigDef.Importance.LOW)
                 .defaultValue("Date")
-                .validator(Validators.validEnum(TargetType.class))
+                .validator(Validators.validEnum(TimestampNowFieldTargetType.class))
                 .build()
         );
-  }
-
-  public enum TargetType {
-    Date(),
-    Unix(),
   }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldConfig.java
@@ -17,21 +17,42 @@ package com.github.jcustenborder.kafka.connect.transform.common;
 
 import com.github.jcustenborder.kafka.connect.utils.config.ConfigKeyBuilder;
 import com.github.jcustenborder.kafka.connect.utils.config.ConfigUtils;
+import com.github.jcustenborder.kafka.connect.utils.config.validators.ValidChronoUnit;
+import com.github.jcustenborder.kafka.connect.utils.config.validators.Validators;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Set;
 
 class TimestampNowFieldConfig extends AbstractConfig {
   public static final String FIELDS_CONF = "fields";
+  public static final String ADD_AMOUNT_CONF = "add.amount";
+  public static final String ADD_CHRONO_UNIT_CONF = "add.chronounit";
+
+  public static final String TARGET_TYPE_CONF = "target.type";
+
   public static final String FIELDS_DOC = "The field(s) that will be inserted with the timestamp of the system.";
 
+  public static final String ADD_AMOUNT_DOC = "how many of the chosen ChronoUnits to add on top of the timestamp of the system.";
+
+  public static final String ADD_CHRONO_UNIT_DOC = "String representation of the ChronoUnit to add, eg: 'DAYS'";
+
+  public static final String TARGET_TYPE_DOC = "The desired timestamp representation: Unix, Date";
+
   public final Set<String> fields;
+  public final Long addAmount;
+  public final ChronoUnit addChronoUnit;
+
+  public final TargetType targetType;
 
   public TimestampNowFieldConfig(Map<?, ?> originals) {
     super(config(), originals);
     this.fields = ConfigUtils.getSet(this, FIELDS_CONF);
+    this.addAmount = getLong(ADD_AMOUNT_CONF);
+    this.addChronoUnit = ChronoUnit.valueOf(getString(ADD_CHRONO_UNIT_CONF));
+    this.targetType = ConfigUtils.getEnum(TargetType.class, this, TARGET_TYPE_CONF);
   }
 
   public static ConfigDef config() {
@@ -41,6 +62,31 @@ class TimestampNowFieldConfig extends AbstractConfig {
                 .documentation(FIELDS_DOC)
                 .importance(ConfigDef.Importance.HIGH)
                 .build()
+        ).define(
+            ConfigKeyBuilder.of(ADD_AMOUNT_CONF, ConfigDef.Type.LONG)
+                .documentation(ADD_AMOUNT_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue("0")
+                .build()
+        ).define(
+            ConfigKeyBuilder.of(ADD_CHRONO_UNIT_CONF, ConfigDef.Type.STRING)
+                .documentation(ADD_CHRONO_UNIT_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue("DAYS")
+                .validator(new ValidChronoUnit())
+                .build()
+        ).define(
+            ConfigKeyBuilder.of(TARGET_TYPE_CONF, ConfigDef.Type.STRING)
+                .documentation(TARGET_TYPE_DOC)
+                .importance(ConfigDef.Importance.LOW)
+                .defaultValue("Date")
+                .validator(Validators.validEnum(TargetType.class))
+                .build()
         );
+  }
+
+  public enum TargetType {
+    Date(),
+    Unix(),
   }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTargetType.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTargetType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.jcustenborder.kafka.connect.transform.common;
 
 import org.apache.kafka.connect.data.Schema;
@@ -7,42 +22,42 @@ import java.time.Instant;
 import java.util.Date;
 
 public enum TimestampNowFieldTargetType {
-    DATE {
-        @Override
-        boolean isMatchingSchema(Schema schema) {
-            return Timestamp.SCHEMA.type() == getSchema().type() && Timestamp.SCHEMA.name().equals(schema.name());
-        }
+  DATE {
+    @Override
+    boolean isMatchingSchema(Schema schema) {
+      return Timestamp.SCHEMA.type() == getSchema().type() && Timestamp.SCHEMA.name().equals(schema.name());
+    }
 
-        @Override
-        Schema getSchema() {
-            return Timestamp.SCHEMA;
-        }
+    @Override
+    Schema getSchema() {
+      return Timestamp.SCHEMA;
+    }
 
-        @Override
-        Object getFormattedTimestamp(long timeInMillis) {
-            return new Date(timeInMillis);
-        }
-    },
-    UNIX {
-        @Override
-        boolean isMatchingSchema(Schema schema) {
-            return Schema.Type.INT64 == schema.type() && null == schema.name();
-        }
+    @Override
+    Object getFormattedTimestamp(long timeInMillis) {
+      return new Date(timeInMillis);
+    }
+  },
+  UNIX {
+    @Override
+    boolean isMatchingSchema(Schema schema) {
+      return Schema.Type.INT64 == schema.type() && null == schema.name();
+    }
 
-        @Override
-        Schema getSchema() {
-            return Schema.INT64_SCHEMA;
-        }
+    @Override
+    Schema getSchema() {
+      return Schema.INT64_SCHEMA;
+    }
 
-        @Override
-        Object getFormattedTimestamp(long timeInMillis) {
-            return Instant.ofEpochMilli(timeInMillis).getEpochSecond();
-        }
-    };
+    @Override
+    Object getFormattedTimestamp(long timeInMillis) {
+      return Instant.ofEpochMilli(timeInMillis).getEpochSecond();
+    }
+  };
 
-    abstract boolean isMatchingSchema(Schema schema);
+  abstract boolean isMatchingSchema(Schema schema);
 
-    abstract Schema getSchema();
+  abstract Schema getSchema();
 
-    abstract Object getFormattedTimestamp(long timeInMillis);
+  abstract Object getFormattedTimestamp(long timeInMillis);
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTargetType.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTargetType.java
@@ -1,0 +1,48 @@
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.time.Instant;
+import java.util.Date;
+
+public enum TimestampNowFieldTargetType {
+    DATE {
+        @Override
+        boolean isMatchingSchema(Schema schema) {
+            return Timestamp.SCHEMA.type() == getSchema().type() && Timestamp.SCHEMA.name().equals(schema.name());
+        }
+
+        @Override
+        Schema getSchema() {
+            return Timestamp.SCHEMA;
+        }
+
+        @Override
+        Object getFormattedTimestamp(long timeInMillis) {
+            return new Date(timeInMillis);
+        }
+    },
+    UNIX {
+        @Override
+        boolean isMatchingSchema(Schema schema) {
+            return Schema.Type.INT64 == schema.type() && null == schema.name();
+        }
+
+        @Override
+        Schema getSchema() {
+            return Schema.INT64_SCHEMA;
+        }
+
+        @Override
+        Object getFormattedTimestamp(long timeInMillis) {
+            return Instant.ofEpochMilli(timeInMillis).getEpochSecond();
+        }
+    };
+
+    abstract boolean isMatchingSchema(Schema schema);
+
+    abstract Schema getSchema();
+
+    abstract Object getFormattedTimestamp(long timeInMillis);
+}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/validators/ValidChronoUnit.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/validators/ValidChronoUnit.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.jcustenborder.kafka.connect.utils.config.validators;
 
 import com.google.common.base.Joiner;
@@ -10,38 +25,38 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ValidChronoUnit implements ConfigDef.Validator {
-    List<String> validOptions = Arrays.stream(ChronoUnit.values()).map(ChronoUnit::name).collect(Collectors.toList());
+  List<String> validOptions = Arrays.stream(ChronoUnit.values()).map(ChronoUnit::name).collect(Collectors.toList());
 
-    @Override
-    public void ensureValid(String s, Object o) {
-        if (o instanceof String) {
-            if (!validOptions.contains(o)) {
-                throw new ConfigException(
-                        s,
-                        String.format(
-                                "'%s' is not a valid value for %s. Valid values are %s.",
-                                o,
-                                ChronoUnit.class.getSimpleName(),
-                                Joiner.on(", ").join(validOptions)
-                        )
-                );
-            }
-        } else if (o instanceof List) {
-            List list = (List) o;
-            for (Object i : list) {
-                ensureValid(s, i);
-            }
-        } else {
-            throw new ConfigException(
-                    s,
-                    o,
-                    "Must be a String or List"
-            );
-        }
+  @Override
+  public void ensureValid(String s, Object o) {
+    if (o instanceof String) {
+      if (!validOptions.contains(o)) {
+        throw new ConfigException(
+          s,
+          String.format(
+            "'%s' is not a valid value for %s. Valid values are %s.",
+            o,
+            ChronoUnit.class.getSimpleName(),
+            Joiner.on(", ").join(validOptions)
+          )
+        );
+      }
+    } else if (o instanceof List) {
+      List list = (List) o;
+      for (Object i : list) {
+        ensureValid(s, i);
+      }
+    } else {
+      throw new ConfigException(
+        s,
+        o,
+        "Must be a String or List"
+      );
     }
+  }
 
-    @Override
-    public String toString() {
-        return "Matches: ``" + Joiner.on("``, ``").join(this.validOptions) + "``";
-    }
+  @Override
+  public String toString() {
+    return "Matches: ``" + Joiner.on("``, ``").join(this.validOptions) + "``";
+  }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/validators/ValidChronoUnit.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/validators/ValidChronoUnit.java
@@ -1,0 +1,47 @@
+package com.github.jcustenborder.kafka.connect.utils.config.validators;
+
+import com.google.common.base.Joiner;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ValidChronoUnit implements ConfigDef.Validator {
+    List<String> validOptions = Arrays.stream(ChronoUnit.values()).map(ChronoUnit::name).collect(Collectors.toList());
+
+    @Override
+    public void ensureValid(String s, Object o) {
+        if (o instanceof String) {
+            if (!validOptions.contains(o)) {
+                throw new ConfigException(
+                        s,
+                        String.format(
+                                "'%s' is not a valid value for %s. Valid values are %s.",
+                                o,
+                                ChronoUnit.class.getSimpleName(),
+                                Joiner.on(", ").join(validOptions)
+                        )
+                );
+            }
+        } else if (o instanceof List) {
+            List list = (List) o;
+            for (Object i : list) {
+                ensureValid(s, i);
+            }
+        } else {
+            throw new ConfigException(
+                    s,
+                    o,
+                    "Must be a String or List"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Matches: ``" + Joiner.on("``, ``").join(this.validOptions) + "``";
+    }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
@@ -10,13 +10,12 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -110,8 +109,100 @@ public class TimestampNowFieldTest {
     assertNotNull(output, "output should not be null.");
     assertTrue(output.value() instanceof Struct, "value should be a struct");
     final Struct actualStruct = (Struct) output.value();
+    System.out.println(actualStruct);
     assertStruct(expectedStruct, actualStruct);
   }
+  @Test
+  public void structFieldMissingAddOneDay() {
+    Date timestampPlusOneDay = Date.from(timestamp.toInstant().plus(1, ChronoUnit.DAYS));
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
+                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS"
+            )
+    );
+    final Schema inputSchema = SchemaBuilder.struct()
+            .name("something")
+            .field("firstName", Schema.STRING_SCHEMA)
+            .field("lastName", Schema.STRING_SCHEMA)
+            .build();
+    final Schema expectedSchema = SchemaBuilder.struct()
+            .name("something")
+            .field("firstName", Schema.STRING_SCHEMA)
+            .field("lastName", Schema.STRING_SCHEMA)
+            .field("timestamp", Timestamp.SCHEMA)
+            .build();
+    final Struct inputStruct = new Struct(inputSchema)
+            .put("firstName", "example")
+            .put("lastName", "user");
+    final Struct expectedStruct = new Struct(expectedSchema)
+            .put("firstName", "example")
+            .put("lastName", "user")
+            .put("timestamp", timestampPlusOneDay);
+    final SinkRecord input = new SinkRecord(
+            "test",
+            1,
+            null,
+            null,
+            inputSchema,
+            inputStruct,
+            1234L
+    );
+    final SinkRecord output = this.transformation.apply(input);
+    assertNotNull(output, "output should not be null.");
+    assertTrue(output.value() instanceof Struct, "value should be a struct");
+    final Struct actualStruct = (Struct) output.value();
+    System.out.println(actualStruct);
+    assertStruct(expectedStruct, actualStruct);
+  }
+
+  @Test
+  public void structFieldMissingAddOneDayFormattedAsUnix() {
+    long timestampPlusOneDayFormattedAsUnix = timestamp.toInstant().plus(1, ChronoUnit.DAYS).getEpochSecond();
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
+                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS",
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, "Unix"
+            )
+    );
+    final Schema inputSchema = SchemaBuilder.struct()
+            .name("something")
+            .field("firstName", Schema.STRING_SCHEMA)
+            .field("lastName", Schema.STRING_SCHEMA)
+            .build();
+    final Schema expectedSchema = SchemaBuilder.struct()
+            .name("something")
+            .field("firstName", Schema.STRING_SCHEMA)
+            .field("lastName", Schema.STRING_SCHEMA)
+            .field("timestamp", Schema.INT64_SCHEMA)
+            .build();
+    final Struct inputStruct = new Struct(inputSchema)
+            .put("firstName", "example")
+            .put("lastName", "user");
+    final Struct expectedStruct = new Struct(expectedSchema)
+            .put("firstName", "example")
+            .put("lastName", "user")
+            .put("timestamp", timestampPlusOneDayFormattedAsUnix);
+    final SinkRecord input = new SinkRecord(
+            "test",
+            1,
+            null,
+            null,
+            inputSchema,
+            inputStruct,
+            1234L
+    );
+    final SinkRecord output = this.transformation.apply(input);
+    assertNotNull(output, "output should not be null.");
+    assertTrue(output.value() instanceof Struct, "value should be a struct");
+    final Struct actualStruct = (Struct) output.value();
+    System.out.println(actualStruct);
+    assertStruct(expectedStruct, actualStruct);
+  }
+
   @Test
   public void structFieldMismatch() {
     final Schema inputSchema = SchemaBuilder.struct()
@@ -162,6 +253,65 @@ public class TimestampNowFieldTest {
         null,
         ImmutableMap.of("firstName", "example", "lastName", "user"),
         1234L
+    );
+    final SinkRecord output = this.transformation.apply(input);
+    assertNotNull(output, "output should not be null.");
+    assertTrue(output.value() instanceof Map, "value should be a struct");
+    final Map<String, Object> actual = (Map<String, Object>) output.value();
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void mapFieldMissingAddOneDay() {
+    Date timestampPlusOneDay = Date.from(timestamp.toInstant().plus(1, ChronoUnit.DAYS));
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
+                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS"
+            )
+    );
+    final Map<String, Object> expected = ImmutableMap.of(
+            "firstName", "example", "lastName", "user", "timestamp", timestampPlusOneDay
+    );
+    final SinkRecord input = new SinkRecord(
+            "test",
+            1,
+            null,
+            null,
+            null,
+            ImmutableMap.of("firstName", "example", "lastName", "user"),
+            1234L
+    );
+    final SinkRecord output = this.transformation.apply(input);
+    assertNotNull(output, "output should not be null.");
+    assertTrue(output.value() instanceof Map, "value should be a struct");
+    final Map<String, Object> actual = (Map<String, Object>) output.value();
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void mapFieldMissingAddOneDayFormattedAsUnix() {
+    long timestampPlusOneDayFormattedAsUnix = timestamp.toInstant().plus(1, ChronoUnit.DAYS).getEpochSecond();
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
+                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS",
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, "Unix"
+            )
+    );
+    final Map<String, Object> expected = ImmutableMap.of(
+            "firstName", "example", "lastName", "user", "timestamp", timestampPlusOneDayFormattedAsUnix
+    );
+    final SinkRecord input = new SinkRecord(
+            "test",
+            1,
+            null,
+            null,
+            null,
+            ImmutableMap.of("firstName", "example", "lastName", "user"),
+            1234L
     );
     final SinkRecord output = this.transformation.apply(input);
     assertNotNull(output, "output should not be null.");

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
@@ -289,7 +289,7 @@ public class TimestampNowFieldTest {
     this.transformation.configure(
             ImmutableMap.of(
                     TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
-                    TimestampNowFieldConfig.TARGET_TYPE_CONF, "Unix"
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, "UNIX"
             )
     );
     final Map<String, Object> expected = ImmutableMap.of(

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
@@ -9,6 +9,8 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -22,12 +24,11 @@ import static org.mockito.Mockito.when;
 public class TimestampNowFieldTest {
 
   TimestampNowField<SinkRecord> transformation;
-  Date timestamp = new Date(1586963336123L);
+  static Date timestamp = new Date(1586963336123L);
 
   @BeforeEach
   public void beforeEach() {
     this.transformation = new TimestampNowField.Value<>();
-    Date timestamp = new Date(1586963336123L);
     Time time = mock(Time.class);
     when(time.milliseconds()).thenReturn(timestamp.getTime());
     this.transformation.time = time;
@@ -35,13 +36,37 @@ public class TimestampNowFieldTest {
         ImmutableMap.of(TimestampNowFieldConfig.FIELDS_CONF, "timestamp")
     );
   }
+
   @BeforeEach
   public void afterEach() {
     this.transformation.close();
   }
 
-  @Test
-  public void structFieldMissing() {
+  enum StructUseCases {
+    Date(TimestampNowFieldConfig.TargetType.Date, Timestamp.SCHEMA, timestamp),
+    Unix(TimestampNowFieldConfig.TargetType.Unix, Schema.INT64_SCHEMA, timestamp.toInstant().getEpochSecond());
+
+    public final TimestampNowFieldConfig.TargetType targetType;
+    public final Schema schema;
+    public final Object value;
+
+
+    StructUseCases(TimestampNowFieldConfig.TargetType targetType, Schema schema, Object value) {
+      this.targetType = targetType;
+      this.schema = schema;
+      this.value = value;
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(StructUseCases.class)
+  public void structFieldMissing(StructUseCases useCase) {
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, useCase.targetType.name()
+            )
+    );
     final Schema inputSchema = SchemaBuilder.struct()
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
@@ -51,7 +76,7 @@ public class TimestampNowFieldTest {
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
         .field("lastName", Schema.STRING_SCHEMA)
-        .field("timestamp", Timestamp.SCHEMA)
+        .field("timestamp", useCase.schema)
         .build();
     final Struct inputStruct = new Struct(inputSchema)
         .put("firstName", "example")
@@ -59,7 +84,7 @@ public class TimestampNowFieldTest {
     final Struct expectedStruct = new Struct(expectedSchema)
         .put("firstName", "example")
         .put("lastName", "user")
-        .put("timestamp", timestamp);
+        .put("timestamp", useCase.value);
     final SinkRecord input = new SinkRecord(
         "test",
         1,
@@ -75,8 +100,16 @@ public class TimestampNowFieldTest {
     final Struct actualStruct = (Struct) output.value();
     assertStruct(expectedStruct, actualStruct);
   }
-  @Test
-  public void structFieldExists() {
+
+  @ParameterizedTest
+  @EnumSource(StructUseCases.class)
+  public void structFieldExists(StructUseCases useCase) {
+    this.transformation.configure(
+            ImmutableMap.of(
+                    TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, useCase.targetType.name()
+            )
+    );
     final Schema inputSchema = SchemaBuilder.struct()
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
@@ -87,7 +120,7 @@ public class TimestampNowFieldTest {
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
         .field("lastName", Schema.STRING_SCHEMA)
-        .field("timestamp", Timestamp.SCHEMA)
+        .field("timestamp", useCase.schema)
         .build();
     final Struct inputStruct = new Struct(inputSchema)
         .put("firstName", "example")
@@ -95,7 +128,7 @@ public class TimestampNowFieldTest {
     final Struct expectedStruct = new Struct(expectedSchema)
         .put("firstName", "example")
         .put("lastName", "user")
-        .put("timestamp", timestamp);
+        .put("timestamp", useCase.value);
     final SinkRecord input = new SinkRecord(
         "test",
         1,
@@ -109,11 +142,11 @@ public class TimestampNowFieldTest {
     assertNotNull(output, "output should not be null.");
     assertTrue(output.value() instanceof Struct, "value should be a struct");
     final Struct actualStruct = (Struct) output.value();
-    System.out.println(actualStruct);
     assertStruct(expectedStruct, actualStruct);
   }
+
   @Test
-  public void structFieldMissingAddOneDay() {
+  public void structAddOneDay() {
     Date timestampPlusOneDay = Date.from(timestamp.toInstant().plus(1, ChronoUnit.DAYS));
     this.transformation.configure(
             ImmutableMap.of(
@@ -153,58 +186,18 @@ public class TimestampNowFieldTest {
     assertNotNull(output, "output should not be null.");
     assertTrue(output.value() instanceof Struct, "value should be a struct");
     final Struct actualStruct = (Struct) output.value();
-    System.out.println(actualStruct);
     assertStruct(expectedStruct, actualStruct);
   }
 
-  @Test
-  public void structFieldMissingAddOneDayFormattedAsUnix() {
-    long timestampPlusOneDayFormattedAsUnix = timestamp.toInstant().plus(1, ChronoUnit.DAYS).getEpochSecond();
+  @ParameterizedTest
+  @EnumSource(StructUseCases.class)
+  public void structFieldMismatch(StructUseCases useCase) {
     this.transformation.configure(
             ImmutableMap.of(
                     TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
-                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
-                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS",
-                    TimestampNowFieldConfig.TARGET_TYPE_CONF, "Unix"
+                    TimestampNowFieldConfig.TARGET_TYPE_CONF, useCase.targetType.name()
             )
     );
-    final Schema inputSchema = SchemaBuilder.struct()
-            .name("something")
-            .field("firstName", Schema.STRING_SCHEMA)
-            .field("lastName", Schema.STRING_SCHEMA)
-            .build();
-    final Schema expectedSchema = SchemaBuilder.struct()
-            .name("something")
-            .field("firstName", Schema.STRING_SCHEMA)
-            .field("lastName", Schema.STRING_SCHEMA)
-            .field("timestamp", Schema.INT64_SCHEMA)
-            .build();
-    final Struct inputStruct = new Struct(inputSchema)
-            .put("firstName", "example")
-            .put("lastName", "user");
-    final Struct expectedStruct = new Struct(expectedSchema)
-            .put("firstName", "example")
-            .put("lastName", "user")
-            .put("timestamp", timestampPlusOneDayFormattedAsUnix);
-    final SinkRecord input = new SinkRecord(
-            "test",
-            1,
-            null,
-            null,
-            inputSchema,
-            inputStruct,
-            1234L
-    );
-    final SinkRecord output = this.transformation.apply(input);
-    assertNotNull(output, "output should not be null.");
-    assertTrue(output.value() instanceof Struct, "value should be a struct");
-    final Struct actualStruct = (Struct) output.value();
-    System.out.println(actualStruct);
-    assertStruct(expectedStruct, actualStruct);
-  }
-
-  @Test
-  public void structFieldMismatch() {
     final Schema inputSchema = SchemaBuilder.struct()
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
@@ -215,7 +208,7 @@ public class TimestampNowFieldTest {
         .name("something")
         .field("firstName", Schema.STRING_SCHEMA)
         .field("lastName", Schema.STRING_SCHEMA)
-        .field("timestamp", Timestamp.SCHEMA)
+        .field("timestamp", useCase.schema)
         .build();
     final Struct inputStruct = new Struct(inputSchema)
         .put("firstName", "example")
@@ -223,7 +216,7 @@ public class TimestampNowFieldTest {
     final Struct expectedStruct = new Struct(expectedSchema)
         .put("firstName", "example")
         .put("lastName", "user")
-        .put("timestamp", timestamp);
+        .put("timestamp", useCase.value);
     final SinkRecord input = new SinkRecord(
         "test",
         1,
@@ -262,7 +255,7 @@ public class TimestampNowFieldTest {
   }
 
   @Test
-  public void mapFieldMissingAddOneDay() {
+  public void mapAddOneDay() {
     Date timestampPlusOneDay = Date.from(timestamp.toInstant().plus(1, ChronoUnit.DAYS));
     this.transformation.configure(
             ImmutableMap.of(
@@ -291,18 +284,16 @@ public class TimestampNowFieldTest {
   }
 
   @Test
-  public void mapFieldMissingAddOneDayFormattedAsUnix() {
-    long timestampPlusOneDayFormattedAsUnix = timestamp.toInstant().plus(1, ChronoUnit.DAYS).getEpochSecond();
+  public void mapFormattedAsUnix() {
+    long timestampFormattedAsUnix = timestamp.toInstant().getEpochSecond();
     this.transformation.configure(
             ImmutableMap.of(
                     TimestampNowFieldConfig.FIELDS_CONF, "timestamp",
-                    TimestampNowFieldConfig.ADD_AMOUNT_CONF, "1",
-                    TimestampNowFieldConfig.ADD_CHRONO_UNIT_CONF, "DAYS",
                     TimestampNowFieldConfig.TARGET_TYPE_CONF, "Unix"
             )
     );
     final Map<String, Object> expected = ImmutableMap.of(
-            "firstName", "example", "lastName", "user", "timestamp", timestampPlusOneDayFormattedAsUnix
+            "firstName", "example", "lastName", "user", "timestamp", timestampFormattedAsUnix
     );
     final SinkRecord input = new SinkRecord(
             "test",

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/TimestampNowFieldTest.java
@@ -43,15 +43,15 @@ public class TimestampNowFieldTest {
   }
 
   enum StructUseCases {
-    Date(TimestampNowFieldConfig.TargetType.Date, Timestamp.SCHEMA, timestamp),
-    Unix(TimestampNowFieldConfig.TargetType.Unix, Schema.INT64_SCHEMA, timestamp.toInstant().getEpochSecond());
+    Date(TimestampNowFieldTargetType.DATE, Timestamp.SCHEMA, timestamp),
+    Unix(TimestampNowFieldTargetType.UNIX, Schema.INT64_SCHEMA, timestamp.toInstant().getEpochSecond());
 
-    public final TimestampNowFieldConfig.TargetType targetType;
+    public final TimestampNowFieldTargetType targetType;
     public final Schema schema;
     public final Object value;
 
 
-    StructUseCases(TimestampNowFieldConfig.TargetType targetType, Schema schema, Object value) {
+    StructUseCases(TimestampNowFieldTargetType targetType, Schema schema, Object value) {
       this.targetType = targetType;
       this.schema = schema;
       this.value = value;


### PR DESCRIPTION
This adds the following options to the TimestampNowField transformer:

- add.amount "how many of the chosen ChronoUnits to add on top of the timestamp of the system."
- add.chronounit "String representation of the ChronoUnit to add, eg: 'DAYS'"
- target.type "The desired timestamp representation: Unix, Date"

All of these options have sane defaults to ensure backward compatibility.
The idea behind the first two is that DynamoDB expects a TTL value per item inserted.
The idea behind the last option is that the current implementation outputs time since epoch in milliseconds. DynamoDB expects a TTL value in Unix time, which is the time since epoch in seconds.


The current `ValidEnum` and `ConfigUtils::getEnum` don't agree with each other on which field to use for the `ChronoUnit` enum. One uses `ChronoUnit::name` the other uses the enum value.
We could handle this on 2 ways.

1. Move `ValidChronoUnit` to [connect-utils](https://github.com/jcustenborder/connect-utils) this would mean we use values like "DAYS".
2. Make `ValidEnum` and `ConfigUtils::getEnum` play nice with `ChronoUnit` this would mean we use values like "Days"
From my limited experience with adding my own enum for the target type, it seems option 1 would be more in line with existing things.