### PR TITLE
Allow BytesToString transformer to handle null values

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToString.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToString.java
@@ -55,7 +55,9 @@ public abstract class BytesToString<R extends ConnectRecord<R>> extends BaseTran
   @Override
   protected SchemaAndValue processBytes(R record, Schema inputSchema, byte[] input) {
     final Schema outputSchema = inputSchema.isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA;
-    final String output = new String(input, this.config.charset);
+    final String output =  input != null
+            ?  new String(input, this.config.charset)
+            : (String) inputSchema.defaultValue();
     return new SchemaAndValue(outputSchema, output);
   }
 
@@ -91,7 +93,12 @@ public abstract class BytesToString<R extends ConnectRecord<R>> extends BaseTran
     for (Field field : schema.fields()) {
       if (this.config.fields.contains(field.name())) {
         byte[] buffer = input.getBytes(field.name());
-        struct.put(field.name(), new String(buffer, this.config.charset));
+        struct.put(
+                field.name(),
+                buffer != null
+                  ?  new String(buffer, this.config.charset)
+                : field.schema().defaultValue()
+        );
       } else {
         struct.put(field.name(), input.get(field.name()));
       }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToStringTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/BytesToStringTest.java
@@ -68,6 +68,52 @@ public abstract class BytesToStringTest extends TransformationTest {
     assertSchema(Schema.STRING_SCHEMA, outputRecord.valueSchema());
   }
 
+  @Test
+  public void nullBytes() throws UnsupportedEncodingException {
+    this.transformation.configure(
+            ImmutableMap.of()
+    );
+    final String expected =  null;
+    final SinkRecord inputRecord = new SinkRecord(
+            "topic",
+            1,
+            null,
+            null,
+            Schema.OPTIONAL_BYTES_SCHEMA,
+            expected,
+            1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+    assertEquals(expected, outputRecord.value());
+    assertSchema(Schema.OPTIONAL_STRING_SCHEMA, outputRecord.valueSchema());
+  }
+
+  @Test
+  public void nullStructFieldBytes() throws UnsupportedEncodingException {
+    this.transformation.configure(
+            ImmutableMap.of(BytesToStringConfig.FIELD_CONFIG, "bytes")
+    );
+    final String expected =  null;
+    Schema schema = SchemaBuilder.struct()
+            .field("bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema)
+            .put("bytes", expected);
+
+    final SinkRecord inputRecord = new SinkRecord(
+            "topic",
+            1,
+            null,
+            null,
+            schema,
+            struct,
+            1L
+    );
+
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+  }
+
   public static class ValueTest<R extends ConnectRecord<R>> extends BytesToStringTest {
     protected ValueTest() {
       super(false);


### PR DESCRIPTION
Just a few updates and a pair of tests. I tested it with a struct pipeline and it worked like a charm.