### PR TITLE
Hotfix: null value condition has to be considered on the recursion of ChangeCase smt

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
@@ -65,6 +65,10 @@ public abstract class ChangeCase<R extends ConnectRecord<R>> extends BaseTransfo
 
   private Struct convertStruct(Schema inputSchema, Schema outputSchema, Struct input) {
     final Struct struct = new Struct(outputSchema);
+
+    if (input == null)
+      return struct;
+
     for (Field inputField : inputSchema.fields()) {
       final int index = inputField.index();
       final Field outputField = outputSchema.fields().get(index);


### PR DESCRIPTION
fix: https://github.com/jcustenborder/kafka-connect-transform-common/pull/102

Currently, error like below is raised when the `null` value with any schema exists in the struct.
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.kafka.connect.data.Struct.get(org.apache.kafka.connect.data.Field)" because "input" is null
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertStruct(ChangeCase.java:73)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertValue(ChangeCase.java:82)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertStruct(ChangeCase.java:73)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertValue(ChangeCase.java:82)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertStruct(ChangeCase.java:73)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertValue(ChangeCase.java:82)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.convertStruct(ChangeCase.java:73)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase.processStruct(ChangeCase.java:62)
	at com.github.jcustenborder.kafka.connect.transform.common.BaseTransformation.process(BaseTransformation.java:131)
	at com.github.jcustenborder.kafka.connect.transform.common.ChangeCase$Value.apply(ChangeCase.java:169)
	at org.apache.kafka.connect.runtime.TransformationChain.lambda$apply$0(TransformationChain.java:50)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:180)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:214)
	... 15 more
```