### PR TITLE
Harden ExtractXPath against XXE

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
@@ -20,6 +20,7 @@ import com.github.jcustenborder.kafka.connect.utils.config.DocumentationTip;
 import com.github.jcustenborder.kafka.connect.utils.config.Title;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -35,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
@@ -79,6 +81,15 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setNamespaceAware(config.namespaceAware);
+      // Harden against XXE: reject DOCTYPE declarations and disable external entity/DTD
+      // resolution so untrusted XML cannot read local files or reach external URLs.
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
       builder = factory.newDocumentBuilder();
       xpath = XPathFactory.newInstance().newXPath();
       if (config.namespaceAware) {
@@ -97,7 +108,10 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
       DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
       writer = impl.createLSSerializer();
     } catch (Exception e) {
-      log.error("Unable to create transformer {} {}", e.getMessage(), e.toString());
+      // Fail closed: never run with a null/unhardened parser. Previously this exception was
+      // swallowed, which could leave the transform operating without the XXE protections above.
+      log.error("Unable to configure ExtractXPath transform", e);
+      throw new ConnectException("Unable to configure ExtractXPath transform", e);
     }
   }
   

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPath.java
@@ -81,15 +81,22 @@ public abstract class ExtractXPath<R extends ConnectRecord<R>> extends BaseTrans
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setNamespaceAware(config.namespaceAware);
-      // Harden against XXE: reject DOCTYPE declarations and disable external entity/DTD
-      // resolution so untrusted XML cannot read local files or reach external URLs.
-      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      factory.setXIncludeAware(false);
-      factory.setExpandEntityReferences(false);
+      if (config.secureProcessing) {
+        // Harden against XXE: reject DOCTYPE declarations and disable external entity/DTD
+        // resolution so untrusted XML cannot read local files or reach external URLs. This is
+        // the default; it can be turned off via secure.processing.enabled=false for trusted
+        // input that requires DTDs/entities.
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+      } else {
+        log.warn("secure.processing.enabled=false: XML External Entity (XXE) protections are "
+            + "disabled. Only use this with trusted XML input.");
+      }
       builder = factory.newDocumentBuilder();
       xpath = XPathFactory.newInstance().newXPath();
       if (config.namespaceAware) {

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathConfig.java
@@ -35,6 +35,7 @@ public class ExtractXPathConfig extends AbstractConfig {
   public final boolean namespaceAware;
   public final List<String> prefixes;
   public final List<String> namespaces;
+  public final boolean secureProcessing;
 
   public static final String IN_FIELD_CONFIG = "input.field";
   public static final String IN_FIELD_DOC = "The input field containing the XML Document.";
@@ -46,6 +47,12 @@ public class ExtractXPathConfig extends AbstractConfig {
   public static final String NS_LIST_DOC = "A comma separated list of Namespaces corresponding to the prefixes";
   public static final String XPATH_CONFIG = "xpath";
   public static final String XPATH_DOC = "The XPath to apply to extract an element from the Document";
+  public static final String SECURE_PROCESSING_CONFIG = "secure.processing.enabled";
+  public static final String SECURE_PROCESSING_DOC = "When true (the default), the XML parser is "
+      + "hardened against XXE attacks: DOCTYPE declarations are rejected and external "
+      + "entity/DTD resolution is disabled. Set to false ONLY for trusted input that requires "
+      + "DTDs or entities - doing so re-enables XML External Entity (XXE) processing and must not "
+      + "be used with untrusted XML.";
 
 
 
@@ -54,6 +61,7 @@ public class ExtractXPathConfig extends AbstractConfig {
     this.inputField = getString(IN_FIELD_CONFIG);    
     this.outputField = getString(OUT_FIELD_CONFIG);
     this.xpath = getString(XPATH_CONFIG);
+    this.secureProcessing = getBoolean(SECURE_PROCESSING_CONFIG);
     String prefixString = getString(NS_PREFIX_CONFIG);
     String namespaceString = getString(NS_LIST_CONFIG);
     if (prefixString == null || prefixString.trim().length() == 0) {
@@ -76,7 +84,9 @@ public class ExtractXPathConfig extends AbstractConfig {
     .define(OUT_FIELD_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, OUT_FIELD_DOC)
     .define(XPATH_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, XPATH_DOC)
     .define(NS_LIST_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_LIST_DOC)
-    .define(NS_PREFIX_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_PREFIX_DOC);
+    .define(NS_PREFIX_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, NS_PREFIX_DOC)
+    .define(SECURE_PROCESSING_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+        SECURE_PROCESSING_DOC);
   }
 
 }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -20,6 +20,7 @@ import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSc
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class ExtractXPathTest extends TransformationTest {
@@ -189,6 +190,42 @@ public abstract class ExtractXPathTest extends TransformationTest {
     );
     ExtractXPathConfig xpc = ((ExtractXPath) this.transformation).theConfig();
     assertEquals(xpc.namespaceAware, true);
+  }
+
+  @Test
+  public void xxeExternalEntityIsNotResolved() throws IOException {
+    // A crafted record references a local file via an external entity. With the parser hardened
+    // (DOCTYPE rejected), the file must NOT be read into the output. On an unhardened parser this
+    // would leak the file contents.
+    File secret = File.createTempFile("xxe-secret", ".txt");
+    java.nio.file.Files.write(secret.toPath(), "SECRET-DO-NOT-LEAK".getBytes());
+
+    String xml = "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE r [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
+        + "<r>&xxe;</r>";
+
+    this.transformation.configure(
+      ImmutableMap.of(
+        ExtractXPathConfig.IN_FIELD_CONFIG, "in",
+        ExtractXPathConfig.OUT_FIELD_CONFIG, "out",
+        ExtractXPathConfig.XPATH_CONFIG, "//r")
+    );
+
+    Schema schema = SchemaBuilder.struct()
+      .name("testing")
+      .field("in", Schema.STRING_SCHEMA)
+      .build();
+    Struct struct = new Struct(schema).put("in", xml);
+
+    final SinkRecord inputRecord = new SinkRecord("topic", 1, null, null, schema, struct, 1L);
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+    assertNotNull(outputRecord);
+
+    final Struct actualStruct = (Struct) (isKey ? outputRecord.key() : outputRecord.value());
+    final Object out = actualStruct.get("out");
+    assertFalse(
+        String.valueOf(out).contains("SECRET-DO-NOT-LEAK"),
+        "External entity was resolved - XXE protection is not in effect");
   }
 
   public static class ValueTest<R extends ConnectRecord<R>> extends ExtractXPathTest {

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -218,14 +218,21 @@ public abstract class ExtractXPathTest extends TransformationTest {
     Struct struct = new Struct(schema).put("in", xml);
 
     final SinkRecord inputRecord = new SinkRecord("topic", 1, null, null, schema, struct, 1L);
-    SinkRecord outputRecord = this.transformation.apply(inputRecord);
-    assertNotNull(outputRecord);
 
-    final Struct actualStruct = (Struct) (isKey ? outputRecord.key() : outputRecord.value());
-    final Object out = actualStruct.get("out");
-    assertFalse(
-        String.valueOf(out).contains("SECRET-DO-NOT-LEAK"),
-        "External entity was resolved - XXE protection is not in effect");
+    // With the parser hardened, the DOCTYPE is rejected, so the entity is never expanded. The
+    // transform then either returns a record without the file contents, or fails the record
+    // (e.g. DataException). Either way the secret must never surface. On an unhardened parser
+    // apply() would succeed and the output would contain the file contents.
+    try {
+      SinkRecord outputRecord = this.transformation.apply(inputRecord);
+      String dump = String.valueOf(outputRecord.key()) + String.valueOf(outputRecord.value());
+      assertFalse(dump.contains("SECRET-DO-NOT-LEAK"),
+          "External entity was resolved - XXE protection is not in effect");
+    } catch (org.apache.kafka.connect.errors.DataException expected) {
+      // Record rejected because the malicious XML failed to parse - nothing was read.
+      assertFalse(String.valueOf(expected.getMessage()).contains("SECRET-DO-NOT-LEAK"),
+          "External entity contents leaked into the error");
+    }
   }
 
   public static class ValueTest<R extends ConnectRecord<R>> extends ExtractXPathTest {

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractXPathTest.java
@@ -22,6 +22,7 @@ import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSc
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ExtractXPathTest extends TransformationTest {
   protected ExtractXPathTest(boolean isKey) {
@@ -233,6 +234,39 @@ public abstract class ExtractXPathTest extends TransformationTest {
       assertFalse(String.valueOf(expected.getMessage()).contains("SECRET-DO-NOT-LEAK"),
           "External entity contents leaked into the error");
     }
+  }
+
+  @Test
+  public void doctypeAllowedWhenSecureProcessingDisabled() {
+    // Opt-out: secure.processing.enabled=false restores the previous (permissive) behavior, so a
+    // DOCTYPE with an internal entity is processed and expanded. Uses an internal entity so the
+    // result does not depend on the JVM's accessExternalDTD default.
+    this.transformation.configure(
+      ImmutableMap.of(
+        ExtractXPathConfig.IN_FIELD_CONFIG, "in",
+        ExtractXPathConfig.OUT_FIELD_CONFIG, "out",
+        ExtractXPathConfig.XPATH_CONFIG, "//r",
+        ExtractXPathConfig.SECURE_PROCESSING_CONFIG, "false")
+    );
+
+    String xml = "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE r [ <!ENTITY foo \"INTERNAL-VALUE\"> ]>\n"
+        + "<r>&foo;</r>";
+
+    Schema schema = SchemaBuilder.struct()
+      .name("testing")
+      .field("in", Schema.STRING_SCHEMA)
+      .build();
+    Struct struct = new Struct(schema).put("in", xml);
+
+    final SinkRecord inputRecord = new SinkRecord("topic", 1, null, null, schema, struct, 1L);
+    SinkRecord outputRecord = this.transformation.apply(inputRecord);
+    assertNotNull(outputRecord);
+
+    final Struct actualStruct = (Struct) (isKey ? outputRecord.key() : outputRecord.value());
+    assertTrue(
+        String.valueOf(actualStruct.get("out")).contains("INTERNAL-VALUE"),
+        "DOCTYPE/internal entity should be processed when secure.processing.enabled=false");
   }
 
   public static class ValueTest<R extends ConnectRecord<R>> extends ExtractXPathTest {


### PR DESCRIPTION
## Harden ExtractXPath against XXE

`ExtractXPath` parses record data with a `DocumentBuilderFactory` that is created with default settings, which leaves DTD processing and external entity resolution enabled. When the XML being parsed is untrusted, this allows XML External Entity (XXE) attacks — e.g. a document with

```xml
<!DOCTYPE r [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>
<r>&x;</r>
```

causes the parser to read a local file (or fetch an external URL) and fold its contents into the record.

### Changes

- Harden the `DocumentBuilderFactory` before use (applied by default):
  - `disallow-doctype-decl = true` (rejects DOCTYPE outright — the primary guard; also stops internal entity-expansion / "billion laughs"),
  - external general/parameter entities disabled,
  - external DTD loading disabled,
  - `FEATURE_SECURE_PROCESSING = true`, XInclude disabled, entity-reference expansion disabled.
- Add a config to gate this — **`secure.processing.enabled` (boolean, default `true`)**:
  - `true` (default) → the hardening above is applied.
  - `false` → the parser is left permissive (logged with a warning) for trusted input that genuinely needs DTDs/entities. Documented as unsafe for untrusted XML.
- Make `configure()` **fail closed**: it previously caught and only *logged* setup exceptions, which could leave the transform running with a null/unhardened parser. It now rethrows so the transform never operates without the configured protections.

### Compatibility

Secure-by-default, with an opt-out so existing users aren't broken:

- The default (`secure.processing.enabled=true`) rejects documents that rely on an inline `<!DOCTYPE>` (internal entities / DTD validation). Data-interchange XML flowing through Connect does not normally use a DOCTYPE — for example SOAP (a primary use case here) forbids DTDs in messages — so well-formed messages are unaffected.
- Users who require DTD/entity processing can set `secure.processing.enabled=false` to restore the previous behavior. This re-enables XXE processing and should only be used with trusted input.

These are the standard OWASP recommendations for parsing untrusted XML.

### Testing

- `ExtractXPathTest#xxeExternalEntityIsNotResolved` — with the default (hardened) config, a record whose XML references a local temp file via an external entity must **not** leak the file contents (whether the record is returned or rejected). Fails on the previous behavior; passes now.
- `ExtractXPathTest#doctypeAllowedWhenSecureProcessingDisabled` — with `secure.processing.enabled=false`, a DOCTYPE with an internal entity is processed and expanded, confirming the opt-out restores the previous parsing.

Full module build + test suite pass locally:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.843 s
[INFO] Finished at: 2026-06-30T20:08:33+05:30
[INFO] ------------------------------------------------------------------------
```
