### PR TITLE
Fix ChangeCase string keys and values

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
@@ -57,6 +57,14 @@ public abstract class ChangeCase<R extends ConnectRecord<R>> extends BaseTransfo
   Map<Schema, Schema> schemaState = new HashMap<>();
 
   @Override
+  protected SchemaAndValue process(R record, Schema inputSchema, Object input) {
+    if (inputSchema == null && input instanceof String) {
+      return processString(record, null, (String) input);
+    }
+    return super.process(record, inputSchema, input);
+  }
+
+  @Override
   protected SchemaAndValue processStruct(R record, Schema inputSchema, Struct input) {
     final Schema outputSchema = this.schemaState.computeIfAbsent(inputSchema, schema -> convertSchema(schema));
     final Struct outputStruct = convertStruct(inputSchema, outputSchema, input);

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCase.java
@@ -63,6 +63,11 @@ public abstract class ChangeCase<R extends ConnectRecord<R>> extends BaseTransfo
     return new SchemaAndValue(outputSchema, outputStruct);
   }
 
+  @Override
+  protected SchemaAndValue processString(R record, Schema inputSchema, String input) {
+    return new SchemaAndValue(inputSchema, input == null ? null : this.config.from.to(this.config.to, input));
+  }
+
   private Struct convertStruct(Schema inputSchema, Schema outputSchema, Struct input) {
     final Struct struct = new Struct(outputSchema);
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCaseTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCaseTest.java
@@ -33,6 +33,7 @@ import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSc
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public abstract class ChangeCaseTest extends TransformationTest {
   protected ChangeCaseTest(boolean isKey) {
@@ -70,6 +71,20 @@ public abstract class ChangeCaseTest extends TransformationTest {
 
     assertNotNull(transformedRecord, "transformedRecord should not be null.");
     assertSchema(Schema.STRING_SCHEMA, isKey ? transformedRecord.keySchema() : transformedRecord.valueSchema());
+    assertEquals("first_name", isKey ? transformedRecord.key() : transformedRecord.value());
+  }
+
+  @Test
+  public void schemaLessString() {
+    this.transformation.configure(
+            ImmutableMap.of(ChangeCaseConfig.FROM_CONFIG, CaseFormat.UPPER_UNDERSCORE.toString(),
+                    ChangeCaseConfig.TO_CONFIG, CaseFormat.LOWER_UNDERSCORE.toString()));
+    final SinkRecord inputRecord = record(null, "FIRST_NAME");
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    assertNull(isKey ? transformedRecord.keySchema() : transformedRecord.valueSchema());
     assertEquals("first_name", isKey ? transformedRecord.key() : transformedRecord.value());
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCaseTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ChangeCaseTest.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 
 import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class ChangeCaseTest extends TransformationTest {
@@ -49,13 +50,39 @@ public abstract class ChangeCaseTest extends TransformationTest {
     final Struct inputStruct = makeStruct(inputSchema, CaseFormat.UPPER_UNDERSCORE);
     final Struct expectedStruct = makeStruct(expectedSchema, CaseFormat.LOWER_UNDERSCORE);
 
-    final SinkRecord inputRecord = new SinkRecord("topic", 1, null, null, inputSchema, inputStruct, 1L);
+    final SinkRecord inputRecord = record(inputSchema, inputStruct);
     for (int i = 0; i < 50; i++) {
       final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
       assertNotNull(transformedRecord, "transformedRecord should not be null.");
-      assertSchema(expectedSchema, transformedRecord.valueSchema());
-      assertStruct(expectedStruct, (Struct) transformedRecord.value());
+      assertSchema(expectedSchema, isKey ? transformedRecord.keySchema() : transformedRecord.valueSchema());
+      assertStruct(expectedStruct, (Struct) (isKey ? transformedRecord.key() : transformedRecord.value()));
     }
+  }
+
+  @Test
+  public void string() {
+    this.transformation.configure(
+            ImmutableMap.of(ChangeCaseConfig.FROM_CONFIG, CaseFormat.UPPER_UNDERSCORE.toString(),
+                    ChangeCaseConfig.TO_CONFIG, CaseFormat.LOWER_UNDERSCORE.toString()));
+    final SinkRecord inputRecord = record(Schema.STRING_SCHEMA, "FIRST_NAME");
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    assertSchema(Schema.STRING_SCHEMA, isKey ? transformedRecord.keySchema() : transformedRecord.valueSchema());
+    assertEquals("first_name", isKey ? transformedRecord.key() : transformedRecord.value());
+  }
+
+  private SinkRecord record(Schema inputSchema, Object input) {
+    return new SinkRecord(
+            "topic",
+            1,
+            isKey ? inputSchema : null,
+            isKey ? input : null,
+            isKey ? null : inputSchema,
+            isKey ? null : input,
+            1L
+    );
   }
 
   private Schema makeSchema(CaseFormat caseFormat) {
@@ -85,6 +112,17 @@ public abstract class ChangeCaseTest extends TransformationTest {
                     )
             )
     );
+  }
+
+  public static class KeyTest<R extends ConnectRecord<R>> extends ChangeCaseTest {
+    protected KeyTest() {
+      super(true);
+    }
+
+    @Override
+    protected Transformation<SinkRecord> create() {
+      return new ChangeCase.Key<>();
+    }
   }
 
   public static class ValueTest<R extends ConnectRecord<R>> extends ChangeCaseTest {


### PR DESCRIPTION
## Summary
- Handle primitive string inputs in ChangeCase for both Key and Value variants.
- Preserve schemaful STRING schemas and schemaless null schemas.
- Add Key coverage alongside existing Value coverage.

## Verification
- JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home" mvn -B -Dtest='ChangeCaseTest$KeyTest,ChangeCaseTest$ValueTest' test
- JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home" mvn -B clean verify
- scripts/validate-cp-8.3.0-plugins.sh

Fixes #106