### PR TITLE
Fix ExtractNestedField null outer struct handling

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedField.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedField.java
@@ -60,7 +60,11 @@ public abstract class ExtractNestedField<R extends ConnectRecord<R>> extends Bas
     final Struct innerStruct = input.getStruct(this.config.outerFieldName);
     final Schema outputSchema = this.schemaCache.computeIfAbsent(inputSchema, s -> {
 
-      final Field innerField = innerStruct.schema().field(this.config.innerFieldName);
+      final Field outerField = inputSchema.field(this.config.outerFieldName);
+      final Field innerField = outerField.schema().field(this.config.innerFieldName);
+      final Schema innerFieldSchema = outerField.schema().isOptional()
+          ? optional(innerField.schema())
+          : innerField.schema();
       final SchemaBuilder builder = SchemaBuilder.struct();
       if (!Strings.isNullOrEmpty(inputSchema.name())) {
         builder.name(inputSchema.name());
@@ -71,7 +75,7 @@ public abstract class ExtractNestedField<R extends ConnectRecord<R>> extends Bas
       for (Field inputField : inputSchema.fields()) {
         builder.field(inputField.name(), inputField.schema());
       }
-      builder.field(this.config.outputFieldName, innerField.schema());
+      builder.field(this.config.outputFieldName, innerFieldSchema);
       return builder.build();
     });
     final Struct outputStruct = new Struct(outputSchema);
@@ -79,11 +83,51 @@ public abstract class ExtractNestedField<R extends ConnectRecord<R>> extends Bas
       final Object value = input.get(inputField);
       outputStruct.put(inputField.name(), value);
     }
-    final Object innerFieldValue = innerStruct.get(this.config.innerFieldName);
+    final Object innerFieldValue = null == innerStruct ? null : innerStruct.get(this.config.innerFieldName);
     outputStruct.put(this.config.outputFieldName, innerFieldValue);
 
     return new SchemaAndValue(outputSchema, outputStruct);
 
+  }
+
+  private static Schema optional(Schema schema) {
+    if (schema.isOptional()) {
+      return schema;
+    }
+
+    final SchemaBuilder builder;
+    switch (schema.type()) {
+      case ARRAY:
+        builder = SchemaBuilder.array(schema.valueSchema());
+        break;
+      case MAP:
+        builder = SchemaBuilder.map(schema.keySchema(), schema.valueSchema());
+        break;
+      case STRUCT:
+        builder = SchemaBuilder.struct();
+        for (Field field : schema.fields()) {
+          builder.field(field.name(), field.schema());
+        }
+        break;
+      default:
+        builder = SchemaBuilder.type(schema.type());
+    }
+    if (!Strings.isNullOrEmpty(schema.name())) {
+      builder.name(schema.name());
+    }
+    if (null != schema.version()) {
+      builder.version(schema.version());
+    }
+    if (!Strings.isNullOrEmpty(schema.doc())) {
+      builder.doc(schema.doc());
+    }
+    if (null != schema.parameters() && !schema.parameters().isEmpty()) {
+      builder.parameters(schema.parameters());
+    }
+    if (null != schema.defaultValue()) {
+      builder.defaultValue(schema.defaultValue());
+    }
+    return builder.optional().build();
   }
 
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ExtractNestedFieldTest extends TransformationTest {
   protected ExtractNestedFieldTest(boolean isKey) {
@@ -87,6 +89,56 @@ public abstract class ExtractNestedFieldTest extends TransformationTest {
       assertSchema(expectedSchema, transformedRecord.valueSchema());
       assertStruct(expectedStruct, (Struct) transformedRecord.value());
     }
+  }
+
+  @Test
+  public void optionalOuterStructSetToNullProducesNullOutputField() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "state",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "address",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "state"
+        )
+    );
+
+    final Schema innerSchema = SchemaBuilder.struct()
+        .name("Address")
+        .optional()
+        .field("city", Schema.STRING_SCHEMA)
+        .field("state", Schema.STRING_SCHEMA)
+        .build();
+    final Schema inputSchema = SchemaBuilder.struct()
+        .field("first_name", Schema.STRING_SCHEMA)
+        .field("last_name", Schema.STRING_SCHEMA)
+        .field("address", innerSchema)
+        .build();
+    final Schema expectedSchema = SchemaBuilder.struct()
+        .field("first_name", Schema.STRING_SCHEMA)
+        .field("last_name", Schema.STRING_SCHEMA)
+        .field("address", innerSchema)
+        .field("state", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Struct inputStruct = new Struct(inputSchema)
+        .put("first_name", "test")
+        .put("last_name", "developer")
+        .put("address", null);
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        inputSchema,
+        inputStruct,
+        1L
+    );
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    assertSchema(expectedSchema, transformedRecord.valueSchema());
+    final Struct transformedStruct = (Struct) transformedRecord.value();
+    assertNull(transformedStruct.get("state"));
+    assertTrue(transformedRecord.valueSchema().field("state").schema().isOptional());
   }
 
 


### PR DESCRIPTION
## Summary
- derive ExtractNestedField output schema from input schema instead of runtime nested struct values
- emit null for the configured output field when the optional outer struct is null
- add regression coverage for null optional outer structs

Closes #81

## Verification
- mvn -B -Dtest='ExtractNestedFieldTest' test
- mvn -B clean verify
- scripts/validate-cp-8.3.0-plugins.sh