### PR TITLE
Add gzip compression transforms

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/GzipCompress.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/GzipCompress.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import com.github.jcustenborder.kafka.connect.utils.config.Description;
+import com.github.jcustenborder.kafka.connect.utils.config.Title;
+import com.github.jcustenborder.kafka.connect.utils.transformation.BaseKeyValueTransformation;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+@Title("GzipCompress")
+@Description("This transformation is used to gzip-compress byte arrays.")
+public abstract class GzipCompress<R extends ConnectRecord<R>> extends BaseKeyValueTransformation<R> {
+  protected GzipCompress(boolean isKey) {
+    super(isKey);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return new ConfigDef();
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected SchemaAndValue process(R record, SchemaAndValue input) {
+    if (input.value() instanceof ByteBuffer) {
+      final Schema inputSchema = null == input.schema() ? Schema.BYTES_SCHEMA : input.schema();
+      if (Schema.Type.BYTES == inputSchema.type()) {
+        return processBytes(record, inputSchema, bytes((ByteBuffer) input.value()));
+      }
+    }
+    return super.process(record, input);
+  }
+
+  static byte[] bytes(ByteBuffer input) {
+    final ByteBuffer buffer = input.slice();
+    final byte[] result = new byte[buffer.remaining()];
+    buffer.get(result);
+    return result;
+  }
+
+  @Override
+  protected SchemaAndValue processBytes(R record, Schema inputSchema, byte[] input) {
+    if (null == input) {
+      return new SchemaAndValue(inputSchema, null);
+    }
+
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream)) {
+        gzipOutputStream.write(input);
+      }
+      return new SchemaAndValue(inputSchema, outputStream.toByteArray());
+    } catch (IOException ex) {
+      throw new DataException(ex);
+    }
+  }
+
+  public static class Key<R extends ConnectRecord<R>> extends GzipCompress<R> {
+    public Key() {
+      super(true);
+    }
+  }
+
+  public static class Value<R extends ConnectRecord<R>> extends GzipCompress<R> {
+    public Value() {
+      super(false);
+    }
+  }
+}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/GzipDecompress.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/transform/common/GzipDecompress.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import com.github.jcustenborder.kafka.connect.utils.config.Description;
+import com.github.jcustenborder.kafka.connect.utils.config.Title;
+import com.github.jcustenborder.kafka.connect.utils.transformation.BaseKeyValueTransformation;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+@Title("GzipDecompress")
+@Description("This transformation is used to gzip-decompress byte arrays.")
+public abstract class GzipDecompress<R extends ConnectRecord<R>> extends BaseKeyValueTransformation<R> {
+  protected GzipDecompress(boolean isKey) {
+    super(isKey);
+  }
+
+  @Override
+  public ConfigDef config() {
+    return new ConfigDef();
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected SchemaAndValue process(R record, SchemaAndValue input) {
+    if (input.value() instanceof ByteBuffer) {
+      final Schema inputSchema = null == input.schema() ? Schema.BYTES_SCHEMA : input.schema();
+      if (Schema.Type.BYTES == inputSchema.type()) {
+        return processBytes(record, inputSchema, bytes((ByteBuffer) input.value()));
+      }
+    }
+    return super.process(record, input);
+  }
+
+  static byte[] bytes(ByteBuffer input) {
+    final ByteBuffer buffer = input.slice();
+    final byte[] result = new byte[buffer.remaining()];
+    buffer.get(result);
+    return result;
+  }
+
+  @Override
+  protected SchemaAndValue processBytes(R record, Schema inputSchema, byte[] input) {
+    if (null == input) {
+      return new SchemaAndValue(inputSchema, null);
+    }
+
+    try (ByteArrayInputStream inputStream = new ByteArrayInputStream(input)) {
+      try (GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream)) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+          gzipInputStream.transferTo(outputStream);
+          return new SchemaAndValue(inputSchema, outputStream.toByteArray());
+        }
+      }
+    } catch (IOException ex) {
+      throw new DataException(ex);
+    }
+  }
+
+  public static class Key<R extends ConnectRecord<R>> extends GzipDecompress<R> {
+    public Key() {
+      super(true);
+    }
+  }
+
+  public static class Value<R extends ConnectRecord<R>> extends GzipDecompress<R> {
+    public Value() {
+      super(false);
+    }
+  }
+}

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -12,6 +12,10 @@ com.github.jcustenborder.kafka.connect.transform.common.ExtractTimestamp$Key
 com.github.jcustenborder.kafka.connect.transform.common.ExtractTimestamp$Value
 com.github.jcustenborder.kafka.connect.transform.common.ExtractXPath$Key
 com.github.jcustenborder.kafka.connect.transform.common.ExtractXPath$Value
+com.github.jcustenborder.kafka.connect.transform.common.GzipCompress$Key
+com.github.jcustenborder.kafka.connect.transform.common.GzipCompress$Value
+com.github.jcustenborder.kafka.connect.transform.common.GzipDecompress$Key
+com.github.jcustenborder.kafka.connect.transform.common.GzipDecompress$Value
 com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Key
 com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Value
 com.github.jcustenborder.kafka.connect.transform.common.LowerCaseTopic

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/GzipCompressionTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/GzipCompressionTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.transform.common;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class GzipCompressionTest {
+  @Test
+  public void valueRoundTripBytes() throws IOException {
+    final byte[] input = "hello gzip value".getBytes(StandardCharsets.UTF_8);
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        Schema.BYTES_SCHEMA,
+        input,
+        1L
+    );
+
+    final Transformation<SinkRecord> compress = new GzipCompress.Value<>();
+    compress.configure(Map.of());
+    final SinkRecord compressedRecord = compress.apply(inputRecord);
+    final byte[] compressed = (byte[]) compressedRecord.value();
+
+    assertFalse(Arrays.equals(input, compressed));
+    assertArrayEquals(input, gunzip(compressed));
+    assertEquals(Schema.BYTES_SCHEMA, compressedRecord.valueSchema());
+
+    final Transformation<SinkRecord> decompress = new GzipDecompress.Value<>();
+    decompress.configure(Map.of());
+    final SinkRecord decompressedRecord = decompress.apply(compressedRecord);
+
+    assertArrayEquals(input, (byte[]) decompressedRecord.value());
+    assertEquals(Schema.BYTES_SCHEMA, decompressedRecord.valueSchema());
+  }
+
+  @Test
+  public void valueRoundTripByteBuffer() {
+    final byte[] input = "hello gzip byte buffer".getBytes(StandardCharsets.UTF_8);
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        Schema.BYTES_SCHEMA,
+        ByteBuffer.wrap(input),
+        1L
+    );
+
+    final Transformation<SinkRecord> compress = new GzipCompress.Value<>();
+    compress.configure(Map.of());
+    final SinkRecord compressedRecord = compress.apply(inputRecord);
+    final byte[] compressed = (byte[]) compressedRecord.value();
+
+    final SinkRecord compressedByteBufferRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        Schema.BYTES_SCHEMA,
+        ByteBuffer.wrap(compressed),
+        1L
+    );
+    final Transformation<SinkRecord> decompress = new GzipDecompress.Value<>();
+    decompress.configure(Map.of());
+    final SinkRecord decompressedRecord = decompress.apply(compressedByteBufferRecord);
+
+    assertArrayEquals(input, (byte[]) decompressedRecord.value());
+    assertEquals(Schema.BYTES_SCHEMA, decompressedRecord.valueSchema());
+  }
+
+  @Test
+  public void keyRoundTripBytes() {
+    final byte[] input = "hello gzip key".getBytes(StandardCharsets.UTF_8);
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        Schema.BYTES_SCHEMA,
+        input,
+        Schema.STRING_SCHEMA,
+        "value",
+        1L
+    );
+
+    final Transformation<SinkRecord> compress = new GzipCompress.Key<>();
+    compress.configure(Map.of());
+    final SinkRecord compressedRecord = compress.apply(inputRecord);
+    final byte[] compressed = (byte[]) compressedRecord.key();
+
+    assertFalse(Arrays.equals(input, compressed));
+    assertEquals(Schema.BYTES_SCHEMA, compressedRecord.keySchema());
+    assertEquals("value", compressedRecord.value());
+
+    final Transformation<SinkRecord> decompress = new GzipDecompress.Key<>();
+    decompress.configure(Map.of());
+    final SinkRecord decompressedRecord = decompress.apply(compressedRecord);
+
+    assertArrayEquals(input, (byte[]) decompressedRecord.key());
+    assertEquals(Schema.BYTES_SCHEMA, decompressedRecord.keySchema());
+    assertEquals("value", decompressedRecord.value());
+  }
+
+  static byte[] gunzip(byte[] input) throws IOException {
+    try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(input))) {
+      try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+        gzipInputStream.transferTo(outputStream);
+        return outputStream.toByteArray();
+      }
+    }
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ServiceLoaderTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ServiceLoaderTest.java
@@ -42,6 +42,10 @@ public class ServiceLoaderTest {
       "com.github.jcustenborder.kafka.connect.transform.common.ExtractTimestamp$Value",
       "com.github.jcustenborder.kafka.connect.transform.common.ExtractXPath$Key",
       "com.github.jcustenborder.kafka.connect.transform.common.ExtractXPath$Value",
+      "com.github.jcustenborder.kafka.connect.transform.common.GzipCompress$Key",
+      "com.github.jcustenborder.kafka.connect.transform.common.GzipCompress$Value",
+      "com.github.jcustenborder.kafka.connect.transform.common.GzipDecompress$Key",
+      "com.github.jcustenborder.kafka.connect.transform.common.GzipDecompress$Value",
       "com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Key",
       "com.github.jcustenborder.kafka.connect.transform.common.HeaderToField$Value",
       "com.github.jcustenborder.kafka.connect.transform.common.LowerCaseTopic",
@@ -79,6 +83,8 @@ public class ServiceLoaderTest {
 
     assertTrue(actual.containsAll(EXPECTED_PROVIDERS), "Missing providers: " + missingProviders(actual));
     assertFalse(actual.contains("com.github.jcustenborder.kafka.connect.transform.common.AdjustPrecisionAndScale"));
+    assertFalse(actual.contains("com.github.jcustenborder.kafka.connect.transform.common.GzipCompress"));
+    assertFalse(actual.contains("com.github.jcustenborder.kafka.connect.transform.common.GzipDecompress"));
     assertFalse(actual.contains("com.github.jcustenborder.kafka.connect.transform.common.HeaderToField"));
     assertFalse(actual.contains("com.github.jcustenborder.kafka.connect.transform.common.SetMaximumPrecision"));
   }


### PR DESCRIPTION
## Summary
- Add GzipCompress and GzipDecompress key/value SMTs for Kafka Connect BYTES values.
- Register the new transformations in the ServiceLoader manifest.
- Add gzip behavior coverage, including ByteBuffer input and JDK gzip compatibility, plus ServiceLoader expectations.

## Test Plan
- JAVA_HOME=\"$(/usr/libexec/java_home -v 17)\" mvn -B clean verify
- JAVA_HOME=\"$(/usr/libexec/java_home -v 17)\" scripts/validate-cp-8.3.0-plugins.sh

Supersedes #41.
Refs #40.